### PR TITLE
Allow protections to be configured by the client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    package_protections (0.64.0)
+    package_protections (0.65.0)
       activesupport
       parse_packwerk
       rubocop
@@ -11,7 +11,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.2.4)
+    activesupport (7.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)

--- a/README.md
+++ b/README.md
@@ -128,6 +128,18 @@ PackageProtections.set_defaults!(packages)
 PackageProtections.set_defaults!(packages.select{|p| p.package_name == 'packs/my_package'})
 ```
 
+## Custom Protections
+
+It's possible to create your own custom protections that go through this interface. To do this, you just need to implement a protection and configure `PackageProtections`.
+
+```ruby
+PackageProtections.configure do |config|
+  config.protections += [MyCustomProtection]
+end
+```
+
+In this example, `MyCustomProtection` needs to implement the `PackageProtections::ProtectionInterface` (for protections powered by `packwerk` that look at new and existing violations) OR `PackageProtections::RubocopProtectionInterface` (for protections powered by `rubocop` that look at the AST). It's recommended to take a look at the existing protections as examples. If you're having any trouble with this, please file an issue and we'll be glad to help.
+
 ## Incorporating into your CI Pipeline
 Your CI pipeline can execute the public API ta and fail if there are any offenses.
 

--- a/lib/package_protections.rb
+++ b/lib/package_protections.rb
@@ -38,20 +38,19 @@ module PackageProtections
   # Implementation of rubocop-based protections
   require 'rubocop/cop/package_protections/namespaced_under_package_name'
 
-  #
-  # These are all of the concrete implementations of the `ProtectionInterface`.
-  # This list is added to when a new protection is created, but in the future,
-  # this list may be injected by the client.
-  #
+
+  class << self
+    extend T::Sig
+
+    sig { params(blk: T.proc.params(arg0: Private::Configuration).void).void }
+    def configure(&blk) # rubocop:disable Lint/UnusedMethodArgument
+      yield(Private.config)
+    end
+  end
+
   sig { returns(T::Array[ProtectionInterface]) }
   def self.all
-    [
-      Private::OutgoingDependencyProtection.new,
-      Private::IncomingPrivacyProtection.new,
-      Private::TypedApiProtection.new,
-      Private::MultipleNamespacesProtection.new,
-      Private::VisibilityProtection.new
-    ]
+    Private.config.protections
   end
 
   #

--- a/lib/package_protections.rb
+++ b/lib/package_protections.rb
@@ -38,12 +38,11 @@ module PackageProtections
   # Implementation of rubocop-based protections
   require 'rubocop/cop/package_protections/namespaced_under_package_name'
 
-
   class << self
     extend T::Sig
 
     sig { params(blk: T.proc.params(arg0: Private::Configuration).void).void }
-    def configure(&blk) # rubocop:disable Lint/UnusedMethodArgument
+    def configure(&blk)
       yield(Private.config)
     end
   end

--- a/lib/package_protections/private.rb
+++ b/lib/package_protections/private.rb
@@ -9,6 +9,7 @@ require 'package_protections/private/outgoing_dependency_protection'
 require 'package_protections/private/metadata_modifiers'
 require 'package_protections/private/multiple_namespaces_protection'
 require 'package_protections/private/visibility_protection'
+require 'package_protections/private/configuration'
 
 module PackageProtections
   #
@@ -17,6 +18,12 @@ module PackageProtections
   #
   module Private
     extend T::Sig
+
+    sig { returns(Private::Configuration) }
+    def self.config
+      @config = T.let(@config, T.nilable(Configuration))
+      @config ||= Private::Configuration.new
+    end
 
     sig do
       params(
@@ -138,6 +145,7 @@ module PackageProtections
     def self.bust_cache!
       @protected_packages_indexed_by_name = nil
       @private_cop_config = nil
+      config.bust_cache!
     end
 
     sig { params(identifier: Identifier).returns(T::Hash[T.untyped, T.untyped]) }

--- a/lib/package_protections/private/configuration.rb
+++ b/lib/package_protections/private/configuration.rb
@@ -10,23 +10,28 @@ module PackageProtections
 
       sig { void }
       def initialize
-        @protections = T.let(@protections, T.nilable(T::Array[ProtectionInterface]))
+        @protections = T.let(default_protections, T::Array[ProtectionInterface])
       end
 
       sig { returns(T::Array[ProtectionInterface]) }
       def protections
-        @protections ||= [
+        @protections
+      end
+
+      sig { void }
+      def bust_cache!
+        @protections = default_protections
+      end
+
+      sig { returns(T::Array[ProtectionInterface]) }
+      def default_protections
+        [
           Private::OutgoingDependencyProtection.new,
           Private::IncomingPrivacyProtection.new,
           Private::TypedApiProtection.new,
           Private::MultipleNamespacesProtection.new,
           Private::VisibilityProtection.new
         ]
-      end
-
-      sig { void }
-      def bust_cache!
-        @protections = nil
       end
     end
   end

--- a/lib/package_protections/private/configuration.rb
+++ b/lib/package_protections/private/configuration.rb
@@ -7,7 +7,7 @@ module PackageProtections
 
       sig { params(protections: T::Array[ProtectionInterface]).void }
       attr_writer :protections
- 
+
       sig { void }
       def initialize
         @protections = T.let(@protections, T.nilable(T::Array[ProtectionInterface]))

--- a/lib/package_protections/private/configuration.rb
+++ b/lib/package_protections/private/configuration.rb
@@ -1,0 +1,33 @@
+# typed: strict
+
+module PackageProtections
+  module Private
+    class Configuration
+      extend T::Sig
+
+      sig { params(protections: T::Array[ProtectionInterface]).void }
+      attr_writer :protections
+ 
+      sig { void }
+      def initialize
+        @protections = T.let(@protections, T.nilable(T::Array[ProtectionInterface]))
+      end
+
+      sig { returns(T::Array[ProtectionInterface]) }
+      def protections
+        @protections ||= [
+          Private::OutgoingDependencyProtection.new,
+          Private::IncomingPrivacyProtection.new,
+          Private::TypedApiProtection.new,
+          Private::MultipleNamespacesProtection.new,
+          Private::VisibilityProtection.new
+        ]
+      end
+
+      sig { void }
+      def bust_cache!
+        @protections = nil
+      end
+    end
+  end
+end

--- a/package_protections.gemspec
+++ b/package_protections.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'package_protections'
-  spec.version       = '0.64.0'
+  spec.version       = '0.65.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['stephan.hagemann@gusto.com']
   spec.summary       = 'Package protections for Rails apps'

--- a/spec/package_protections_spec.rb
+++ b/spec/package_protections_spec.rb
@@ -183,6 +183,28 @@ describe PackageProtections do
           'packs/apples', message, file, 'prevent_this_package_from_violating_its_stated_dependencies'
         )
       end
+
+      it 'respects the configured protections' do
+        PackageProtections.configure do |config|
+          config.protections = []
+        end
+        write_package_yml('packs/apples', protections: { 'prevent_this_package_from_violating_its_stated_dependencies' => 'fail_on_any' })
+        write_package_yml('packs/trees')
+
+        write_file('packs/apples/deprecated_references.yml', <<~YML.strip)
+          ---
+          "packs/trees":
+            "Trees::Tree":
+              violations:
+              - dependency
+              files:
+              - packs/apples/models/apples/apple.rb
+        YML
+
+        expect { PackageProtections.get_offenses(packages: get_packages, new_violations: []) }.to raise_error(PackageProtections::IncorrectPublicApiUsageError) do |e|
+          expect(e.message).to eq 'Invalid configuration for package `packs/trees`. The metadata keys ["prevent_this_package_from_violating_its_stated_dependencies", "prevent_other_packages_from_using_this_packages_internals", "prevent_this_package_from_exposing_an_untyped_api", "prevent_this_package_from_creating_other_namespaces", "prevent_other_packages_from_using_this_package_without_explicit_visibility"] are not valid behaviors under the `protection` metadata namespace. Valid keys are []. See https://github.com/bigrails/package_protections#readme for more info'
+        end
+      end
     end
 
     describe 'the protections' do

--- a/spec/package_protections_spec.rb
+++ b/spec/package_protections_spec.rb
@@ -188,18 +188,8 @@ describe PackageProtections do
         PackageProtections.configure do |config|
           config.protections = []
         end
-        write_package_yml('packs/apples', protections: { 'prevent_this_package_from_violating_its_stated_dependencies' => 'fail_on_any' })
-        write_package_yml('packs/trees')
 
-        write_file('packs/apples/deprecated_references.yml', <<~YML.strip)
-          ---
-          "packs/trees":
-            "Trees::Tree":
-              violations:
-              - dependency
-              files:
-              - packs/apples/models/apples/apple.rb
-        YML
+        write_package_yml('packs/trees')
 
         expect { PackageProtections.get_offenses(packages: get_packages, new_violations: []) }.to raise_error(PackageProtections::IncorrectPublicApiUsageError) do |e|
           expect(e.message).to eq 'Invalid configuration for package `packs/trees`. The metadata keys ["prevent_this_package_from_violating_its_stated_dependencies", "prevent_other_packages_from_using_this_packages_internals", "prevent_this_package_from_exposing_an_untyped_api", "prevent_this_package_from_creating_other_namespaces", "prevent_other_packages_from_using_this_package_without_explicit_visibility"] are not valid behaviors under the `protection` metadata namespace. Valid keys are []. See https://github.com/bigrails/package_protections#readme for more info'


### PR DESCRIPTION
This will allow clients to call `PackageProtections.configure { ... }` to implement and add their own custom protections.